### PR TITLE
fix: syntax error in `set.tokenlist.json`

### DIFF
--- a/set.tokenlist.json
+++ b/set.tokenlist.json
@@ -606,9 +606,8 @@
       "symbol": "GII",
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/SetProtocol/uniswap-tokenlist/main/assets/tokens/green-indexes-GII.png"
-    }
-  ],
-  {
+    },
+    {
       "chainId": 1,
       "address": "0x69d1ea48b91cb934fec02c562d9e9b55211eda63",
       "name": "BASIC ISLAND INDEX",
@@ -616,7 +615,7 @@
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/SetProtocol/uniswap-tokenlist/blob/main/assets/tokens/logo%20on%20dark.jpg"
     },
-{
+    {
       "chainId": 1,
       "address": "0x69d1ea48b91cb934fec02c562d9e9b55211eda63",
       "name": "BASIC ISLAND METAVERSE",
@@ -624,6 +623,7 @@
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/SetProtocol/uniswap-tokenlist/blob/main/assets/tokens/logo%20on%20dark.jpg"
     }
+  ],
   "version": {
     "major": 0,
     "minor": 5,


### PR DESCRIPTION
# Summary

We use Set token list on https://dxstats.eth.limo. The `set.tokenlist.json` file is not valid, hence breaking our production deployment. 

This PR fixes the JSON file format.